### PR TITLE
Disable broken link to MPDL

### DIFF
--- a/pages/cv/data__standardization.md
+++ b/pages/cv/data__standardization.md
@@ -81,7 +81,7 @@ jsondict = {
 ## Links
 ### General
 <!-- TODO: Fix broken link to MPDL. (see #71) -->
-- Research Data Management - Max Planck Digital Library (MPDL) - https://rdm.mpdl.mpg.de/
+- Research Data Management - Max Planck Digital Library (MPDL - rdm.mpdl.mpg.de)
 
 ### Data Packages
 - https://frictionlessdata.io/

--- a/pages/cv/data__standardization.md
+++ b/pages/cv/data__standardization.md
@@ -88,7 +88,7 @@ jsondict = {
 
 ## Links
 ### General
-- [Research Data Management - Max Planck Digital Library (MPDL)](https://rdm.mpdl.mpg.de/)
+- Research Data Management - Max Planck Digital Library (MPDL) - https://rdm.mpdl.mpg.de/
 
 ### Data Packages
 - https://frictionlessdata.io/

--- a/pages/cv/data__standardization.md
+++ b/pages/cv/data__standardization.md
@@ -78,16 +78,9 @@ jsondict = {
 }]
 ```
 
-
-
-
-
-
-
-
-
 ## Links
 ### General
+<!-- TODO: Fix broken link to MPDL. (see #71) -->
 - Research Data Management - Max Planck Digital Library (MPDL) - https://rdm.mpdl.mpg.de/
 
 ### Data Packages


### PR DESCRIPTION
Currently, the tests raise an error caused by the link to MPDL.
I disabled the link temporarily. Since the page `data_stdandardization.md` is anyway not yet styled properly, it is also not important that the link works properly. (see #71)