### PR TITLE
Add collapsible `figure description` to cv_entry.md

### DIFF
--- a/templates/cv_entry.md
+++ b/templates/cv_entry.md
@@ -26,6 +26,13 @@ The figure shows {{ entry.figure_description.type }} data.
 {% if entry.figure_description.comment %}
 Note from the curator: {{ entry.figure_description.comment }}
 {% endif %}
+<details>
+<summary>Click to expand complete figure metadata (yaml).</summary>
+
+```yaml
+{{ entry.figure_desctiption.yaml }}
+```
+</details>
 
 <!-- TODO: Make download link work, i.e., build .zip package and link to it here. See #31. -->
 [Download datapackage with ID-XXXXXXXX](#TODO)

--- a/templates/cv_entry.md
+++ b/templates/cv_entry.md
@@ -30,7 +30,7 @@ Note from the curator: {{ entry.figure_description.comment }}
 <summary>Click to expand complete figure metadata (yaml).</summary>
 
 ```yaml
-{{ entry.figure_desctiption.yaml }}
+{{ entry.figure_description.yaml }}
 ```
 </details>
 


### PR DESCRIPTION
We probably still need to decide on the final design once all building blocks are included in `cv_entry.md`.

So it would be great to merge this to get an overview on all items that we might want to rearrange in a more efinal version.