### PR TITLE
Fix TOC

### DIFF
--- a/pages/NAVIGATION.md
+++ b/pages/NAVIGATION.md
@@ -1,7 +1,3 @@
 * [Home](index.md)
 * [CV](cv/)
-  * [Periodic Table](cv/periodic__table.md)
-  * [Systems](cv/systems.md)
-  * [Apps](cv/apps.md)
-  * [Data Standardization](cv/data__standardization.md)
 * [About](about.md)


### PR DESCRIPTION
The CV TOC is defined in cv/NAVIGATION.md already and should not be set
on the top level.