### PR TITLE
Filtering with non-existent entries.

### DIFF
--- a/echemdb/data/cv/database.py
+++ b/echemdb/data/cv/database.py
@@ -8,14 +8,14 @@ Create a database from local data packages in the `data/` directory::
     >>> from echemdb.data.local import collect_datapackages
     >>> database = Database(collect_datapackages('data/'))
 
+Create a database from the data packages published in the echemdb::
+
+    >>> database = Database()  # doctest: +REMOTE_DATA
+
 Search the database for a single publication::
 
     >>> database.filter(lambda entry: entry.source.doi == '10.1039/C0CP01001D')  # doctest: +REMOTE_DATA
     [Entry('alves_2011_electrochemistry_6010_p2_2a_solid')]
-
-Create a database from the data packages published in the echemdb::
-
-    >>> database = Database()  # doctest: +REMOTE_DATA
 
 """
 # ********************************************************************
@@ -126,7 +126,7 @@ class Database:
         EXAMPLES::
 
             >>> database = Database.create_example()
-            >>> database.filter(lambda entry: entry.source.doi == r'10.1039/C0CP01001D')
+            >>> database.filter(lambda entry: entry.source.doi == '10.1039/C0CP01001D')
             [Entry('alves_2011_electrochemistry_6010_p2_2a_solid')]
 
         """

--- a/echemdb/data/cv/database.py
+++ b/echemdb/data/cv/database.py
@@ -8,14 +8,14 @@ Create a database from local data packages in the `data/` directory::
     >>> from echemdb.data.local import collect_datapackages
     >>> database = Database(collect_datapackages('data/'))
 
-Create a database from the data packages published in the echemdb::
-
-    >>> database = Database()  # doctest: +REMOTE_DATA
-
 Search the database for a single publication::
 
     >>> database.filter(lambda entry: entry.source.doi == 'https://doi.org/10.1039/C0CP01001D')  # doctest: +REMOTE_DATA
     [Entry('alves_2011_electrochemistry_6010_p2_2a_solid')]
+
+Create a database from the data packages published in the echemdb::
+
+    >>> database = Database()  # doctest: +REMOTE_DATA
 
 """
 # ********************************************************************

--- a/echemdb/data/cv/database.py
+++ b/echemdb/data/cv/database.py
@@ -10,7 +10,7 @@ Create a database from local data packages in the `data/` directory::
 
 Search the database for a single publication::
 
-    >>> database.filter(lambda entry: entry.source.doi == 'https://doi.org/10.1039/C0CP01001D')  # doctest: +REMOTE_DATA
+    >>> database.filter(lambda entry: entry.source.doi == '10.1039/C0CP01001D')  # doctest: +REMOTE_DATA
     [Entry('alves_2011_electrochemistry_6010_p2_2a_solid')]
 
 Create a database from the data packages published in the echemdb::
@@ -126,7 +126,7 @@ class Database:
         EXAMPLES::
 
             >>> database = Database.create_example()
-            >>> database.filter(lambda entry: entry.source.doi == 'https://doi.org/10.1039/C0CP01001D')
+            >>> database.filter(lambda entry: entry.source.doi == r'10.1039/C0CP01001D')
             [Entry('alves_2011_electrochemistry_6010_p2_2a_solid')]
 
         """

--- a/echemdb/data/cv/descriptor.py
+++ b/echemdb/data/cv/descriptor.py
@@ -105,11 +105,10 @@ class GenericDescriptor:
         """
         name = name.replace('_', ' ')
         
-        try:
-            if name in self._descriptor:
-                return Descriptor(self._descriptor[name])
-        except:
-            print(f"Descriptor has no entry {name}. Did you mean one of {[key.replace(' ', '_') for key in self._descriptor.keys()]}?")
+        if name in self._descriptor:
+            return Descriptor(self._descriptor[name])
+
+        return UndefinedDescriptor()
 
     def __getitem__(self, name):
         r"""
@@ -122,11 +121,10 @@ class GenericDescriptor:
             0
 
         """
-        try:
-            if name in self._descriptor:
-                return Descriptor(self._descriptor[name])
-        except:
-            print(f"Descriptor has no entry {name}. Did you mean one of {list(self._descriptor.keys())}?")
+        if name in self._descriptor:
+            return Descriptor(self._descriptor[name])
+
+        return UndefinedDescriptor()
 
     def __repr__(self):
         r"""
@@ -205,6 +203,44 @@ class QuantityDescriptor(GenericDescriptor):
         return str(self.quantity)
 
 
+class UndefinedDescriptor:
+    def __dir__(self):
+        return object.__dir__(self)
+    
+    def __getitem__(self, name):
+        return self
+
+    def __getattr__(self, name):
+        return self
+
+    def __bool__(self):
+        return False
+
+    def __repr__(self):
+        return ""
+
+    def __str__(self):
+        return ""
+
+    def __eq__(self, other):
+        return False
+
+    def __ne__(self, other):
+        return True
+
+    def __lt__(self, other):
+        return True
+
+    def __gt__(self, other):
+        return True
+
+    def __le__(self, other):
+        return False
+
+    def __ge__(self, other):
+        return False
+
+
 def Descriptor(descriptor):
     r"""
     Return `descriptor` augmented with additional convenience methods.
@@ -238,6 +274,9 @@ def Descriptor(descriptor):
     """
 
     if isinstance(descriptor, GenericDescriptor):
+        return descriptor
+
+    if isinstance(descriptor, UndefinedDescriptor):
         return descriptor
 
     if isinstance(descriptor, dict):

--- a/echemdb/data/cv/descriptor.py
+++ b/echemdb/data/cv/descriptor.py
@@ -104,10 +104,12 @@ class GenericDescriptor:
 
         """
         name = name.replace('_', ' ')
-        if name in self._descriptor:
-            return Descriptor(self._descriptor[name])
-
-        raise AttributeError(f"Descriptor has no entry {name}. Did you mean one of {[key.replace(' ', '_') for key in self._descriptor.keys()]}?")
+        
+        try:
+            if name in self._descriptor:
+                return Descriptor(self._descriptor[name])
+        except:
+            print(f"Descriptor has no entry {name}. Did you mean one of {[key.replace(' ', '_') for key in self._descriptor.keys()]}?")
 
     def __getitem__(self, name):
         r"""
@@ -120,10 +122,11 @@ class GenericDescriptor:
             0
 
         """
-        if name in self._descriptor:
-            return Descriptor(self._descriptor[name])
-
-        raise KeyError(f"Descriptor has no entry {name}. Did you mean one of {list(self._descriptor.keys())}?")
+        try:
+            if name in self._descriptor:
+                return Descriptor(self._descriptor[name])
+        except:
+            print(f"Descriptor has no entry {name}. Did you mean one of {list(self._descriptor.keys())}?")
 
     def __repr__(self):
         r"""

--- a/echemdb/data/cv/entry.py
+++ b/echemdb/data/cv/entry.py
@@ -85,7 +85,7 @@ class Entry:
 
             >>> entry = Entry.create_examples()[0]
             >>> entry.source
-            {'version': 1, 'doi': 'https://doi.org/10.1039/C0CP01001D', 'bib': 'alves_2011_electrochemistry_6010', 'figure': '2a', 'curve': 'solid'}
+            {'version': 1, 'doi': '10.1039/C0CP01001D', 'bib': 'alves_2011_electrochemistry_6010', 'figure': '2a', 'curve': 'solid'}
 
         The returned descriptor can again be accessed in the same way::
 
@@ -103,7 +103,7 @@ class Entry:
 
             >>> entry = Entry.create_examples()[0]
             >>> entry["source"]
-            {'version': 1, 'doi': 'https://doi.org/10.1039/C0CP01001D', 'bib': 'alves_2011_electrochemistry_6010', 'figure': '2a', 'curve': 'solid'}
+            {'version': 1, 'doi': '10.1039/C0CP01001D', 'bib': 'alves_2011_electrochemistry_6010', 'figure': '2a', 'curve': 'solid'}
 
         """
         return self._descriptor[name]

--- a/literature/alves_2011_electrochemistry_6010/alves_2011_electrochemistry_6010_p2_2a_solid.yaml
+++ b/literature/alves_2011_electrochemistry_6010/alves_2011_electrochemistry_6010_p2_2a_solid.yaml
@@ -4,7 +4,7 @@
 
 source:
     version: 1
-    doi: https://doi.org/10.1039/C0CP01001D
+    doi: 10.1039/C0CP01001D
     bib: alves_2011_electrochemistry_6010 # AuthorName_YYYY_FirstWordTitle_pageNr. No prepositions. Fingers crossed that there is no duplicate.
     figure: 2a # depending on the subfigure labels use 1, 1b, or 1_3
     curve: solid # use a unique short description to identify the curve in the figure, i.e.. label, color, etc

--- a/literature/engstfeld_2018_polycrystalline_17743/engstfeld_2018_polycrystalline_17743_4b_1.yaml
+++ b/literature/engstfeld_2018_polycrystalline_17743/engstfeld_2018_polycrystalline_17743_4b_1.yaml
@@ -5,7 +5,7 @@ version: 1
 
 source:
     version: 1
-    doi: https://doi.org/10.1002/chem.201803418
+    doi: 10.1002/chem.201803418
     bib: engstfeld_2018_polycrystalline_17743 # AuthorName_YYYY_FirstWordTitle_pageNr. No prepositions. Fingers crossed that there is no duplicate.
     figure: 4b # depending on the subfigure labels use 1, 1b, or 1_3
     curve: 1 # use a unique short description to identify the curve in the figure


### PR DESCRIPTION
The top-level doctest in `cv.database.py` fails since one of the entries `wang_1997_lateral_1_p1_1a` does not contain a DOI.
```python
r"""
...
Create a database from the data packages published in the echemdb::

    >>> database = Database()  # doctest: +REMOTE_DATA

Search the database for a single publication::

    >>> database.filter(lambda entry: entry.source.doi == 'https://doi.org/10.1039/C0CP01001D')  # doctest: +REMOTE_DATA
    [Entry('alves_2011_electrochemistry_6010_p2_2a_solid')]
"""
```

Upon filtering `cv.descriptor.__getitem__` raises an error that the key does not exist. I solved this issue by changing to `try` `except`. The error is not printed in the doctest (why I do not know). 
If the error message was printed, we would have to change the output of the doctest each time an entry is added to the database that does not contain a DOI.

I suggest changing the doctest and using it on the example database.

Overall the error message is rather useless when filtering since it does not print the database entry for which the respective entry does not exist. 