### PR TITLE
Adapted all docu files to render cell output

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -1,16 +1,15 @@
 ---
-jupyter:
-  jupytext:
-    formats: md,ipynb
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.13.6
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+  formats: md,ipynb
+  text_representation:
+    extension: .md
+    format_name: markdown
+    format_version: '1.3'
+    jupytext_version: 1.13.6
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 ---
 
 Welcome to echemdb's documentation!

--- a/doc/usage/bibliography.md
+++ b/doc/usage/bibliography.md
@@ -1,16 +1,15 @@
 ---
-jupyter:
-  jupytext:
-    formats: md,ipynb
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.13.6
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+  formats: md:myst,ipynb
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.7
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 ---
 
 # Bibliography
@@ -18,21 +17,21 @@ jupyter:
 The bibliography to all entries is stored as a pybtex database `db.bibliography`, 
 which basically contains bibtex entries.
 
-```python
+```{code-cell} ipython3
 from echemdb.data.cv.database import Database
 db = Database()
 ```
 
 Each entry is associated with a citation key.
 
-```python
+```{code-cell} ipython3
 entry = db['alves_2011_electrochemistry_6010_p2_f2a_solid']
 entry.source.citation_key
 ```
 
 as well as the bibliographic details.
 
-```python
+```{code-cell} ipython3
 entry.bibliography
 ```
 
@@ -42,12 +41,12 @@ entry.bibliography
 
 For comparison the the identifier to each entry contains the citation key. 
 
-```python
+```{code-cell} ipython3
 entry.identifier
 ```
 
 The bibliography key of an entry can be used to retrieve the bibliograhy entry directly from the complete database
 
-<!-- #raw -->
+```{raw-cell}
 db.bibliography['alves_2011_electrochemistry_6010']
-<!-- #endraw -->
+```

--- a/doc/usage/database_interactions.md
+++ b/doc/usage/database_interactions.md
@@ -1,52 +1,53 @@
 ---
-jupyter:
-  jupytext:
-    formats: ipynb,md
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.13.6
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.7
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 ---
 
-<!-- #region tags=[] -->
++++ {"tags": []}
+
 # Database interaction
-<!-- #endregion -->
+
++++
 
 The entries on [EchemDB Website](https://echemdb.github.io/website) can be downloaded into a local database.
 
-```python
+```{code-cell} ipython3
 from echemdb.data.cv.database import Database
 db = Database()
 ```
 
 The number of entries in the databse are
 
-```python
+```{code-cell} ipython3
 len(db)
 ```
 
 You can iterate over these entries
 
-```python
+```{code-cell} ipython3
 next(iter(db))
 ```
 
 The database can be filtered for specific descriptors (see below), 
 wherby a new database is created.
 
-```python
+```{code-cell} ipython3
 db_filtered = db.filter(lambda entry: entry.electrochemical_system.electrodes.working_electrode.material == 'Pt')
 print(f'{len(db_filtered)} entries contain Pt as working electrode material.')
 ```
 
 Single entries can be selected by their identifier provided on the [echemDB website](https://echemdb.github.io/website) for each entry.
 
-```python
+```{code-cell} ipython3
 entry = db['alves_2011_electrochemistry_6010_p2_f2a_solid']
 entry
 ```

--- a/doc/usage/entry_interactions.md
+++ b/doc/usage/entry_interactions.md
@@ -1,17 +1,16 @@
 ---
-jupyter:
-  jupytext:
-    cell_metadata_filter: tags,-all
-    formats: md,ipynb
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.13.6
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+  cell_metadata_filter: tags,-all
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.7
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 ---
 
 # Entry interactions
@@ -35,24 +34,24 @@ The underlying information can be retrieved by `entry['name']`,
 where name is the respective descriptor. Alternatively you can write `entry.name` 
 where all spaces should be replaced by underscores.
 
-```python
+```{code-cell} ipython3
 from echemdb.data.cv.database import Database
 db = Database()
 entry = db['alves_2011_electrochemistry_6010_p2_f2a_solid']
 entry
 ```
 
-```python
+```{code-cell} ipython3
 entry['source']
 ```
 
-```python
+```{code-cell} ipython3
 entry.source
 ```
 
 Specific information can be retrieved by selecting the desired descriptor
 
-```python
+```{code-cell} ipython3
 entry.electrochemical_system.electrodes.working_electrode.material
 ```
 
@@ -60,61 +59,61 @@ entry.electrochemical_system.electrodes.working_electrode.material
 
 Entries containing a unit and a value are nicely rendered
 
-```python
+```{code-cell} ipython3
 entry.figure_description.scan_rate
 ```
 
 The unit and value can be accessed separately
 
-```python
+```{code-cell} ipython3
 entry.figure_description.scan_rate.value
 ```
 
-```python
+```{code-cell} ipython3
 entry.figure_description.scan_rate.unit
 ```
 
 All units are compatible with [astropy units](https://docs.astropy.org/en/stable/units/index.html) to create quantities and make simple unit transformations or multiplications with [astropy units](https://docs.astropy.org/en/stable/units/index.html) or [atropy constants](https://docs.astropy.org/en/stable/constants/index.html).
 
-```python
+```{code-cell} ipython3
 from astropy import units as u
 rate = entry.figure_description.scan_rate.value * u.Unit(entry.figure_description.scan_rate.unit)
 rate
 ```
 
-```python
+```{code-cell} ipython3
 type(rate)
 ```
 
-```python
+```{code-cell} ipython3
 rate.to('mV / h')
 ```
 
-```python
+```{code-cell} ipython3
 from astropy import constants as c # c: speed of light
 rate * 25 * u.m * c.c
 ```
 
-<!-- #region tags=[] -->
++++ {"tags": []}
+
 ## Dataframes
 
 The data of an entry can be returned a pandas dataframe.
-<!-- #endregion -->
 
-```python
-entry.df()
+```{code-cell} ipython3
+entry.df().head(3)
 ```
 
 Custom or original figure axes' units can be requested explicitly
 
-```python
-entry.df(xunit='original', yunit='mA / m2')
+```{code-cell} ipython3
+entry.df(xunit='original', yunit='mA / m2').head(3)
 ```
 
 ## Plots
 
 The data can be visualized in a plotly figure, with preferred axis units (default is SI):
 
-```python
+```{code-cell} ipython3
 entry.plot(xunit='V', yunit='original')
 ```

--- a/doc/usage/local_database.md
+++ b/doc/usage/local_database.md
@@ -1,16 +1,15 @@
 ---
-jupyter:
-  jupytext:
-    formats: md,ipynb
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.13.6
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.7
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 ---
 
 # Create database locally

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - defaults
 dependencies:
   - astropy
+  - black
   - filelock
   - inflect
   - jupyterlab


### PR DESCRIPTION
In the current API Docu, the cell output is not rendered. 
All files were changed to `md:myst` format instead of `md`

Locally the cells were executed and were rendered in the preview pages because the ipynb files coexisted with the MD files. These ipynb files are however not uploaded to the repository.