### PR TITLE
linkchecker: Prevent redirects in DOIs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           sleep 1
           # We check for broken links:
           # * ignore fonts.gstatic.com which is mentioned by a link preconnect tag that linkchecker does not parse correctly.
-          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com http://localhost:8880/website/
+          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com http://localhost:8880/website/ --no-follow-url https://doi.org/10.1002/chem.201803418
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           sleep 1
           # We check for broken links:
           # * ignore fonts.gstatic.com which is mentioned by a link preconnect tag that linkchecker does not parse correctly.
-          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com http://localhost:8880/website/ --no-follow-url https://doi.org/10.1002/chem.201803418
+          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com http://localhost:8880/website/ https://onlinelibrary.wiley.com/doi/10.1002/chem.201803418
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           sleep 1
           # We check for broken links:
           # * ignore fonts.gstatic.com which is mentioned by a link preconnect tag that linkchecker does not parse correctly.
-          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com http://localhost:8880/website/ https://onlinelibrary.wiley.com/doi/10.1002/chem.201803418
+          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com http://localhost:8880/website/ --ignore-url=https://doi.org/10.1002/chem.201803418
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Some tests fail since DOIs checked with linkchecker redirect to journal pages, which might not be accessible.

Currently disabled for https://doi.org/10.1002/chem.201803418.