### PR TITLE
Configure arithmatex and MathJax

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -39,3 +39,4 @@ dependencies:
     - python-frontmatter
     - sphinx_rtd_theme>=1,<2
     - svgdigitizer >=0.2.0,<0.3.0
+    - pymdown-extensions>=9.2,<10

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,11 @@ markdown_extensions:
   - attr_list
   - pymdownx.arithmatex:
       generic: true
+      inline_syntax:
+        - dollar
+      block_syntax:
+        - dollar
+        - begin
   - pymdownx.details
   - pymdownx.superfences
   - footnotes
@@ -56,6 +61,6 @@ markdown_extensions:
 extra_javascript:
   - javascripts/config.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js
   - javascripts/tables.js
   - https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.2.1/tablesort.min.js

--- a/pages/javascripts/config.js
+++ b/pages/javascripts/config.js
@@ -1,0 +1,12 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [ ["\\(","\\)"] ],
+    displayMath: [ ["\\[","\\]"] ],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*",
+    processHtmlClass: "arithmatex"
+  }
+};


### PR DESCRIPTION
so that a `(` that has been escaped as `\(` for MarkDown is not treated as
the beginning of an inline formula anymore. Instead, we only consider
formulas inside `$dollar delimiters$`.

Fixes #83

Now, `(111)` shows correctly in this example:

![image](https://user-images.githubusercontent.com/373765/159090372-0bf66f41-0ba8-42fa-b6bc-6b5ce47a3c9d.png)