### PR TITLE
Digitize with a reusable Makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,15 +23,8 @@ jobs:
       - name: digitize
         shell: bash -l {0}
         run: |
-          pushd literature
-          ls ./**/*.yaml | parallel --bar --halt now,fail=1 'svgdigitizer cv --sampling-interval .001 --package --metadata {} {.}.svg --outdir=../data/generated/svgdigitizer/{//}'
-          popd
-      - name: copy literature
-        shell: bash -l {0}
-        run: |
-          pushd literature
-          find . -name '*.bib' | cpio -pdm ../data/generated/svgdigitizer
-          popd
+          cd data
+          make
       - name: install echemdb
         shell: bash -l {0}
         run: |
@@ -82,3 +75,6 @@ jobs:
           # Run tests against the new ZIP archive.
           export ECHEMDB_DATABASE_URL=http://localhost:8880/website/website-gh-pages.zip
           pytest -n auto --doctest-plus --remote-data --doctest-modules echemdb
+
+env:
+  MAKEFLAGS: -j2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,10 @@ concurrency:
 
 jobs:
   build-manual:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v2
         with: { submodules: recursive }
@@ -57,13 +60,15 @@ jobs:
           # We check for broken links:
           # * ignore fonts.gstatic.com which is mentioned by a link preconnect tag that linkchecker does not parse correctly.
           linkchecker --check-extern --no-robots --ignore fonts.gstatic.com http://localhost:8880/website/ --ignore-url=https://doi.org/10.1002/chem.201803418
+        # We only check links on Linux since we do not want to get flagged because of too many requests by the target websites.
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: generated/website
           TARGET_FOLDER: ""
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && matrix.os == 'ubuntu-latest' }}
       - name: doctest against generated website data
         shell: bash -l {0}
         run: |
@@ -75,6 +80,8 @@ jobs:
           # Run tests against the new ZIP archive.
           export ECHEMDB_DATABASE_URL=http://localhost:8880/website/website-gh-pages.zip
           pytest -n auto --doctest-plus --remote-data --doctest-modules echemdb
+        # We only run tests on Linux since we already run tests for all OSes in the test workflow.
+        if: ${{ matrix.os == 'ubuntu-latest' }}
 
 env:
   MAKEFLAGS: -j2

--- a/data/Makefile
+++ b/data/Makefile
@@ -3,7 +3,7 @@ SOURCE_DIR=../literature
 SOURCE_METADATA=${wildcard ${SOURCE_DIR}/**/*.yaml}
 SOURCE_SVG=${patsubst %.yaml,%.svg,${SOURCES_METADATA}}
 
-TARGET_DIR=generated/digitized
+TARGET_DIR=generated/svgdigitizer
 
 TARGET_CSV=${patsubst %.yaml,%.csv,${patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,${wildcard ${SOURCE_DIR}/**/*.yaml}}}
 TARGET_JSON=${patsubst %.yaml,%.json,${patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,${wildcard ${SOURCE_DIR}/**/*.yaml}}}

--- a/data/Makefile
+++ b/data/Makefile
@@ -1,22 +1,22 @@
 SOURCE_DIR=../literature
 
-SOURCE_METADATA=$(wildcard $(SOURCE_DIR)/**/*.yaml)
-SOURCE_SVG=$(patsubst %.yaml,%.svg,$(SOURCES_METADATA))
+SOURCE_METADATA=${wildcard ${SOURCE_DIR}/**/*.yaml}
+SOURCE_SVG=${patsubst %.yaml,%.svg,${SOURCES_METADATA}}
 
 TARGET_DIR=generated/digitized
 
-TARGET_CSV=$(patsubst %.yaml,%.csv,$(patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,$(wildcard $(SOURCE_DIR)/**/*.yaml)))
-TARGET_JSON=$(patsubst %.yaml,%.json,$(patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,$(wildcard $(SOURCE_DIR)/**/*.yaml)))
-TARGET_BIB=$(patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,$(wildcard $(SOURCE_DIR)/**/*.bib))
+TARGET_CSV=${patsubst %.yaml,%.csv,${patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,${wildcard ${SOURCE_DIR}/**/*.yaml}}}
+TARGET_JSON=${patsubst %.yaml,%.json,${patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,${wildcard ${SOURCE_DIR}/**/*.yaml}}}
+TARGET_BIB=${patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,${wildcard ${SOURCE_DIR}/**/*.bib}}
 
-${TARGET_DIR}/%.csv ${TARGET_DIR)}/%.json : $(SOURCE_DIR)/%.yaml $(SOURCE_DIR)/%.svg
-	svgdigitizer cv --sampling-interval .001 --package --metadata $< $(patsubst %.yaml,%.svg,$<) --outdir=$(@D)
+${TARGET_DIR}/%.csv ${TARGET_DIR}/%.json : ${SOURCE_DIR}/%.yaml ${SOURCE_DIR}/%.svg
+	svgdigitizer cv --sampling-interval .001 --package --metadata $< ${patsubst %.yaml,%.svg,$<} --outdir=${@D}
 
-${TARGET_DIR}/%.bib: $(SOURCE_DIR)/%.bib
-	@mkdir -p $(@D)
+${TARGET_DIR}/%.bib: ${SOURCE_DIR}/%.bib
+	@mkdir -p ${@D}
 	cp $< $@
 
-all: $(TARGET_CSV) $(TARGET_JSON) $(TARGET_BIB)
+all: ${TARGET_CSV} ${TARGET_JSON} ${TARGET_BIB}
 
 clean:
 	rm -rf data/generated

--- a/data/Makefile
+++ b/data/Makefile
@@ -21,4 +21,4 @@ all: $(TARGET_CSV) $(TARGET_JSON) $(TARGET_BIB)
 clean:
 	rm -rf data/generated
 
-.PHONY: all
+.PHONY: all clean

--- a/data/Makefile
+++ b/data/Makefile
@@ -1,0 +1,24 @@
+SOURCE_DIR=../literature
+
+SOURCE_METADATA=$(wildcard $(SOURCE_DIR)/**/*.yaml)
+SOURCE_SVG=$(patsubst %.yaml,%.svg,$(SOURCES_METADATA))
+
+TARGET_DIR=generated/digitized
+
+TARGET_CSV=$(patsubst %.yaml,%.csv,$(patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,$(wildcard $(SOURCE_DIR)/**/*.yaml)))
+TARGET_JSON=$(patsubst %.yaml,%.json,$(patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,$(wildcard $(SOURCE_DIR)/**/*.yaml)))
+TARGET_BIB=$(patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,$(wildcard $(SOURCE_DIR)/**/*.bib))
+
+${TARGET_DIR}/%.csv ${TARGET_DIR)}/%.json : $(SOURCE_DIR)/%.yaml $(SOURCE_DIR)/%.svg
+	svgdigitizer cv --sampling-interval .001 --package --metadata $< $(patsubst %.yaml,%.svg,$<) --outdir=$(@D)
+
+${TARGET_DIR}/%.bib: $(SOURCE_DIR)/%.bib
+	@mkdir -p $(@D)
+	cp $< $@
+
+all: $(TARGET_CSV) $(TARGET_JSON) $(TARGET_BIB)
+
+clean:
+	rm -rf data/generated
+
+.PHONY: all

--- a/data/Makefile
+++ b/data/Makefile
@@ -1,24 +1,68 @@
+# ********************************************************************
+#  This file is part of echemdb.
+#
+#        Copyright (C) 2022 Albert Engstfeld
+#        Copyright (C) 2022 Johannes Hermann
+#        Copyright (C) 2022 Julian Rüth
+#        Copyright (C) 2022 Nicolas Hörmann
+#
+#  echemdb is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  echemdb is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with echemdb. If not, see <https://www.gnu.org/licenses/>.
+# ********************************************************************
+
+SVGDIGITIZER=svgdigitizer
+CP=cp
+
+# The sampling interval at which we interpolate in volts.
+SAMPLING_INTERVAL=.001
+
+# The directory which we search for .yaml and .svg files to digitize.
 SOURCE_DIR=../literature
 
+# All the .yaml files in SOURCE_DIR directory and its subdirectories.
 SOURCE_METADATA=${wildcard ${SOURCE_DIR}/**/*.yaml}
+
+# All the .svg files corresponding to the SOURCE_METADATA .yaml files.
 SOURCE_SVG=${patsubst %.yaml,%.svg,${SOURCES_METADATA}}
 
+# The files for the digitized .csv, .json, and .bib are written to this
+# directory with the same subdirectory structure as they had in SOURCE_DIR.
 TARGET_DIR=generated/svgdigitizer
 
+# The .csv files that we are going to generate from the .yaml and .svg files.
 TARGET_CSV=${patsubst %.yaml,%.csv,${patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,${wildcard ${SOURCE_DIR}/**/*.yaml}}}
+# The .json files that we are going to generate from the .yaml and .svg files.
 TARGET_JSON=${patsubst %.yaml,%.json,${patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,${wildcard ${SOURCE_DIR}/**/*.yaml}}}
+# The .bib files that we are going to create, the same .bib files that were present in SOURCE_DIR.
 TARGET_BIB=${patsubst ${SOURCE_DIR}/%,${TARGET_DIR}/%,${wildcard ${SOURCE_DIR}/**/*.bib}}
 
+# We create a data package, i.e., a .csv and a .json file, from a .yaml and a
+# .svg files by invoking the svgdigitizer.
 ${TARGET_DIR}/%.csv ${TARGET_DIR}/%.json : ${SOURCE_DIR}/%.yaml ${SOURCE_DIR}/%.svg
-	svgdigitizer cv --sampling-interval .001 --package --metadata $< ${patsubst %.yaml,%.svg,$<} --outdir=${@D}
+	${SVGDIGITIZER} cv --sampling-interval ${SAMPLING_INTERVAL} --package --metadata $< ${patsubst %.yaml,%.svg,$<} --outdir=${@D}
 
+# We create a .bib file describing a publication by copying the .bib file from SOURCE_DIR to TARGET_DIR.
 ${TARGET_DIR}/%.bib: ${SOURCE_DIR}/%.bib
 	@mkdir -p ${@D}
-	cp $< $@
+	${CP} $< $@
 
+# The default action when calling "make" is to digitize all the .yaml/.svg
+# pairs and copy over all the .bib files.
 all: ${TARGET_CSV} ${TARGET_JSON} ${TARGET_BIB}
 
+# Remove the entire TARGET_DIR to delete all the generated output.
 clean:
 	rm -rf ${TARGET_DIR}
+
 
 .PHONY: all clean

--- a/data/Makefile
+++ b/data/Makefile
@@ -19,6 +19,6 @@ ${TARGET_DIR}/%.bib: ${SOURCE_DIR}/%.bib
 all: ${TARGET_CSV} ${TARGET_JSON} ${TARGET_BIB}
 
 clean:
-	rm -rf data/generated
+	rm -rf ${TARGET_DIR}
 
 .PHONY: all clean

--- a/environment.yml
+++ b/environment.yml
@@ -9,12 +9,12 @@ dependencies:
   - inflect
   - jupyterlab
   - jupytext
+  - make
   - matplotlib
   - mkdocs
   - myst-nb>=0.13.0,<0.14.0
   - myst-parser>=0.15,<0.17
   - pandas
-  - parallel
   - pip
   - plotly
   - pip


### PR DESCRIPTION
To digitize all data
```
cd data
make
```

To run the svgdigitizer in parallel on 8 cores, use instead
```
make -j8
```

We can also only digitize a single data set
```
make generated/svgdigitizer/mello_2018_understanding_J3045/mello_2018_understanding_J3045_p1_f1H_black.csv
```

To digitize data coming from a different source directory than
`literature/` use
```
make SOURCE_DIR=/another/path
```

---

##### TODO

* [x] Add header to Makefile
* [x] Make digitize invocation configurable
* [x] Add documentation, see https://github.com/echemdb/svgdigitizer/issues/146