### PR TITLE
Fix checks of broken DOI links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,8 @@ jobs:
           sleep 1
           # We check for broken links:
           # * ignore fonts.gstatic.com which is mentioned by a link preconnect tag that linkchecker does not parse correctly.
-          # * only check that DOIs are valid but do not check that the journal page resolves since publishers sometimes block GitHub access.
-          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com --no-follow-url='^https://doi.org/.*$' http://localhost:8880/website/
+          # * ignore some specific URLs that work fine in the browser but reject bots.
+          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com --ignore-url='https://doi.org/10.1002/chem.201803418' http://localhost:8880/website/
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           # We check for broken links:
           # * ignore fonts.gstatic.com which is mentioned by a link preconnect tag that linkchecker does not parse correctly.
           # * only check that DOIs are valid but do not check that the journal page resolves since publishers sometimes block GitHub access.
-          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com --no-follow-url='^https://doi.org/' http://localhost:8880/website/
+          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com --no-follow-url='^https://doi.org/.*$' http://localhost:8880/website/
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,8 @@ jobs:
           sleep 1
           # We check for broken links:
           # * ignore fonts.gstatic.com which is mentioned by a link preconnect tag that linkchecker does not parse correctly.
-          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com http://localhost:8880/website/ --ignore-url=https://doi.org/10.1002/chem.201803418
+          # * only check that DOIs are valid but do not check that the journal page resolves since publishers sometimes block GitHub access.
+          linkchecker --check-extern --no-robots --ignore fonts.gstatic.com --no-follow-url='^https://doi.org/' http://localhost:8880/website/
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Btw., Wiley is blocking the linkchecker in general. This has nothing to do with running in a GitHub workflow.

I had misunderstood what `--no-follow-url` is about. This is about following a link to another page and then checking all links on that page as well. This is not about HTTP redirects that we are seeing for DOIs.