### PR TITLE
fix erroneous tag in nakamura_2011_structure_165433_f1a_blue

### DIFF
--- a/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1a_blue.svg
+++ b/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1a_blue.svg
@@ -39,8 +39,8 @@
      inkscape:cy="1281.3121"
      inkscape:window-width="1920"
      inkscape:window-height="1017"
-     inkscape:window-x="-8"
-     inkscape:window-y="32"
+     inkscape:window-x="1912"
+     inkscape:window-y="-3"
      inkscape:window-maximized="1"
      inkscape:current-layer="g105433" />
   <defs
@@ -172,6 +172,6 @@
          sodipodi:role="line"
          id="tspan4629"
          x="-987.39105"
-         y="610.80469">tags: blue</tspan></text>
+         y="610.80469">tags: BCV</tspan></text>
   </g>
 </svg>


### PR DESCRIPTION
The list of tags contained the curve identifier instead of a tag.