### PR TITLE
Change all top level version numbers to strings

### DIFF
--- a/literature/alves_2011_electrochemistry_6010/alves_2011_electrochemistry_6010_f1a_solid.yaml
+++ b/literature/alves_2011_electrochemistry_6010/alves_2011_electrochemistry_6010_f1a_solid.yaml
@@ -53,7 +53,7 @@ source:
   citation key: alves_2011_electrochemistry_6010
   url: https://doi.org/10.1039/C0CP01001D
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/alves_2011_electrochemistry_6010/alves_2011_electrochemistry_6010_f2_red.yaml
+++ b/literature/alves_2011_electrochemistry_6010/alves_2011_electrochemistry_6010_f2_red.yaml
@@ -56,7 +56,7 @@ source:
   citation key: alves_2011_electrochemistry_6010
   url: https://doi.org/10.1039/C0CP01001D
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/berger_2017_lithium_261/berger_2017_lithium_261_f1_inset.yaml
+++ b/literature/berger_2017_lithium_261/berger_2017_lithium_261_f1_inset.yaml
@@ -52,7 +52,7 @@ source:
   url: https://doi.org/10.1002/celc.201600730
   techniques: CV, STM, EQCM
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1a_black.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1a_black.yaml
@@ -37,7 +37,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1a_blue.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1a_blue.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1a_green.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1a_green.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1a_red.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1a_red.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1b_black.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1b_black.yaml
@@ -37,7 +37,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1b_blue.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1b_blue.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1b_green.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1b_green.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1b_red.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1b_red.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1c_black.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1c_black.yaml
@@ -37,7 +37,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1c_blue.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1c_blue.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1c_green.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1c_green.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1c_red.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1c_red.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1d_black.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1d_black.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1d_blue.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1d_blue.yaml
@@ -47,7 +47,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1d_green.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1d_green.yaml
@@ -47,7 +47,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1d_red.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1d_red.yaml
@@ -47,7 +47,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1e_black.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1e_black.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1e_blue.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1e_blue.yaml
@@ -47,7 +47,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1e_green.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1e_green.yaml
@@ -47,7 +47,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1e_red.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1e_red.yaml
@@ -47,7 +47,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1f_black.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1f_black.yaml
@@ -47,7 +47,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1f_blue.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1f_blue.yaml
@@ -52,7 +52,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1f_green.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1f_green.yaml
@@ -52,7 +52,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1f_red.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1f_red.yaml
@@ -52,7 +52,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1g_black.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1g_black.yaml
@@ -47,7 +47,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1g_blue.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1g_blue.yaml
@@ -52,7 +52,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1g_green.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1g_green.yaml
@@ -52,7 +52,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1g_red.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1g_red.yaml
@@ -52,7 +52,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1h_black.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1h_black.yaml
@@ -42,7 +42,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1h_blue.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1h_blue.yaml
@@ -47,7 +47,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1h_green.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1h_green.yaml
@@ -47,7 +47,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1h_red.yaml
+++ b/literature/briega_martos_2018_understanding_j3045/briega_martos_2018_understanding_j3045_p1_f1h_red.yaml
@@ -47,7 +47,7 @@ source:
   techniques:
   - ORR
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Cs_black.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Cs_black.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Cs_blue.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Cs_blue.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Cs_green.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Cs_green.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Cs_pink.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Cs_pink.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Cs_red.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Cs_red.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Li_black.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Li_black.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Li_blue.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Li_blue.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Li_green.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Li_green.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Li_pink.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Li_pink.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Li_red.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Li_red.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Na_black.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Na_black.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Na_blue.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Na_blue.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Na_green.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Na_green.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Na_pink.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Na_pink.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Na_red.yaml
+++ b/literature/briega_martos_2021_cation_48/briega-martos_2021_cation_48_f1Na_red.yaml
@@ -57,7 +57,7 @@ system:
 source:
   citation key: briega_martos_2021_cation_48
   url: https://doi.org/10.1021/acsmeasuresciau.1c00004
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/endo_1999_in-situ_19/endo_1999_in-situ_19_f1_a.yaml
+++ b/literature/endo_1999_in-situ_19/endo_1999_in-situ_19_f1_a.yaml
@@ -43,7 +43,7 @@ source:
   techniques:
   - EXAFS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/endo_1999_in-situ_19/endo_1999_in-situ_19_f1_b.yaml
+++ b/literature/endo_1999_in-situ_19/endo_1999_in-situ_19_f1_b.yaml
@@ -43,7 +43,7 @@ source:
   techniques:
   - EXAFS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/engstfeld_2018_polycrystalline_17743/engstfeld_2018_polycrystalline_17743_f4b_1.yaml
+++ b/literature/engstfeld_2018_polycrystalline_17743/engstfeld_2018_polycrystalline_17743_f4b_1.yaml
@@ -65,7 +65,7 @@ source:
   - XPS 
   - STM
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f1_black.yaml
+++ b/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f1_black.yaml
@@ -38,7 +38,7 @@ source:
   citation key: gomez-marin_2012_surface_558
   url: https://doi.org/10.1016/j.electacta.2012.04.066
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f1_blue.yaml
+++ b/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f1_blue.yaml
@@ -38,7 +38,7 @@ source:
   citation key: gomez-marin_2012_surface_558
   url: https://doi.org/10.1016/j.electacta.2012.04.066
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f1_red.yaml
+++ b/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f1_red.yaml
@@ -38,7 +38,7 @@ source:
   citation key: gomez-marin_2012_surface_558
   url: https://doi.org/10.1016/j.electacta.2012.04.066
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f2_blue.yaml
+++ b/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f2_blue.yaml
@@ -36,7 +36,7 @@ source:
   citation key: gomez-marin_2012_surface_558
   url: https://doi.org/10.1016/j.electacta.2012.04.066
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f2_pink.yaml
+++ b/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f2_pink.yaml
@@ -36,7 +36,7 @@ source:
   citation key: gomez-marin_2012_surface_558
   url: https://doi.org/10.1016/j.electacta.2012.04.066
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f2_red.yaml
+++ b/literature/gomez-marin_2012_surface_558/gomez-marin_2012_surface_558_f2_red.yaml
@@ -36,7 +36,7 @@ source:
   citation key: gomez-marin_2012_surface_558
   url: https://doi.org/10.1016/j.electacta.2012.04.066
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/hamad_2003_electrosorption_211/hamad_2003_electrosorption_211_f1a_dotted.yaml
+++ b/literature/hamad_2003_electrosorption_211/hamad_2003_electrosorption_211_f1a_dotted.yaml
@@ -39,7 +39,7 @@ source:
   - Monte-Carlo simulations
   url: https://doi.org/10.1016/S0022-0728(03)00178-5
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/hamad_2003_electrosorption_211/hamad_2003_electrosorption_211_f1a_solid.yaml
+++ b/literature/hamad_2003_electrosorption_211/hamad_2003_electrosorption_211_f1a_solid.yaml
@@ -44,7 +44,7 @@ source:
   - Monte-Carlo simulations
   url: https://doi.org/10.1016/S0022-0728(03)00178-5
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/horswell_2004_a_10970/horswell_2004_a_10970_f1a_dashed.yaml
+++ b/literature/horswell_2004_a_10970/horswell_2004_a_10970_f1a_dashed.yaml
@@ -44,7 +44,7 @@ source:
   - LEED 
   - RHEED
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/horswell_2004_a_10970/horswell_2004_a_10970_f1a_dotted.yaml
+++ b/literature/horswell_2004_a_10970/horswell_2004_a_10970_f1a_dotted.yaml
@@ -44,7 +44,7 @@ source:
   - LEED 
   - RHEED
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/horswell_2004_a_10970/horswell_2004_a_10970_f1a_solid.yaml
+++ b/literature/horswell_2004_a_10970/horswell_2004_a_10970_f1a_solid.yaml
@@ -44,7 +44,7 @@ source:
   - LEED 
   - RHEED
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f1_dashed.yaml
+++ b/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f1_dashed.yaml
@@ -35,7 +35,7 @@ source:
   citation key: jovic_1999_cyclic_247
   url: https://doi.org/10.1016/S1388-2481(99)00049-1
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f1_solid.yaml
+++ b/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f1_solid.yaml
@@ -35,7 +35,7 @@ source:
   citation key: jovic_1999_cyclic_247
   url: https://doi.org/10.1016/S1388-2481(99)00049-1
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f4_solid.yaml
+++ b/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f4_solid.yaml
@@ -35,7 +35,7 @@ source:
   citation key: jovic_1999_cyclic_247
   url: https://doi.org/10.1016/S1388-2481(99)00049-1
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f6_dashed.yaml
+++ b/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f6_dashed.yaml
@@ -35,7 +35,7 @@ source:
   citation key: jovic_1999_cyclic_247
   url: https://doi.org/10.1016/S1388-2481(99)00049-1
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f6_solid.yaml
+++ b/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f6_solid.yaml
@@ -35,7 +35,7 @@ source:
   citation key: jovic_1999_cyclic_247
   url: https://doi.org/10.1016/S1388-2481(99)00049-1
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f7_dashed.yaml
+++ b/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f7_dashed.yaml
@@ -35,7 +35,7 @@ source:
   citation key: jovic_1999_cyclic_247
   url: https://doi.org/10.1016/S1388-2481(99)00049-1
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f7_solid.yaml
+++ b/literature/jovic_1999_cyclic_247/jovic_1999_cyclic_247_f7_solid.yaml
@@ -35,7 +35,7 @@ source:
   citation key: jovic_1999_cyclic_247
   url: https://doi.org/10.1016/S1388-2481(99)00049-1
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f2a_solid.yaml
+++ b/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f2a_solid.yaml
@@ -35,7 +35,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f3a_thick.yaml
+++ b/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f3a_thick.yaml
@@ -40,7 +40,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f3a_thin.yaml
+++ b/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f3a_thin.yaml
@@ -40,7 +40,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f4a_thick.yaml
+++ b/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f4a_thick.yaml
@@ -40,7 +40,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f4a_thin.yaml
+++ b/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f4a_thin.yaml
@@ -40,7 +40,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f5a_thick.yaml
+++ b/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f5a_thick.yaml
@@ -40,7 +40,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f5a_thin.yaml
+++ b/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f5a_thin.yaml
@@ -40,7 +40,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f6a_1.yaml
+++ b/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f6a_1.yaml
@@ -40,7 +40,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f6a_2.yaml
+++ b/literature/kerner_2002_measurement_2055/kerner_2002_measurement_2055_f6a_2.yaml
@@ -40,7 +40,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/li_2000_chronocoulometric_95/li_2000_chronocoulometric_95_f1_dash-dotted.yaml
+++ b/literature/li_2000_chronocoulometric_95/li_2000_chronocoulometric_95_f1_dash-dotted.yaml
@@ -49,7 +49,7 @@ source:
   citation key: li_2000_chronocoulometric_95
   url: https://doi.org/10.1016/S0022-0728(00)00199-6
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/li_2000_chronocoulometric_95/li_2000_chronocoulometric_95_f1_dashed.yaml
+++ b/literature/li_2000_chronocoulometric_95/li_2000_chronocoulometric_95_f1_dashed.yaml
@@ -49,7 +49,7 @@ source:
   citation key: li_2000_chronocoulometric_95
   url: https://doi.org/10.1016/S0022-0728(00)00199-6
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/li_2000_chronocoulometric_95/li_2000_chronocoulometric_95_f1_dotted.yaml
+++ b/literature/li_2000_chronocoulometric_95/li_2000_chronocoulometric_95_f1_dotted.yaml
@@ -49,7 +49,7 @@ source:
   citation key: li_2000_chronocoulometric_95
   url: https://doi.org/10.1016/S0022-0728(00)00199-6
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/li_2000_chronocoulometric_95/li_2000_chronocoulometric_95_f1_solid.yaml
+++ b/literature/li_2000_chronocoulometric_95/li_2000_chronocoulometric_95_f1_solid.yaml
@@ -44,7 +44,7 @@ source:
   citation key: li_2000_chronocoulometric_95
   url: https://doi.org/10.1016/S0022-0728(00)00199-6
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/lipkowski_1998_ionic_2875/lipkowski_1998_ionic_2875_f1a_Br.yaml
+++ b/literature/lipkowski_1998_ionic_2875/lipkowski_1998_ionic_2875_f1a_Br.yaml
@@ -38,7 +38,7 @@ source:
   - SHG 
   - SXRD
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/lipkowski_1998_ionic_2875/lipkowski_1998_ionic_2875_f1a_Cl.yaml
+++ b/literature/lipkowski_1998_ionic_2875/lipkowski_1998_ionic_2875_f1a_Cl.yaml
@@ -38,7 +38,7 @@ source:
   - SHG 
   - SXRD
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/lipkowski_1998_ionic_2875/lipkowski_1998_ionic_2875_f1a_I.yaml
+++ b/literature/lipkowski_1998_ionic_2875/lipkowski_1998_ionic_2875_f1a_I.yaml
@@ -38,7 +38,7 @@ source:
   - SHG 
   - SXRD
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/lipkowski_1998_ionic_2875/lipkowski_1998_ionic_2875_f1a_SO4.yaml
+++ b/literature/lipkowski_1998_ionic_2875/lipkowski_1998_ionic_2875_f1a_SO4.yaml
@@ -38,7 +38,7 @@ source:
   - SHG 
   - SXRD
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1a_black.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1a_black.yaml
@@ -34,7 +34,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1a_red.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1a_red.yaml
@@ -39,7 +39,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1b_black.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1b_black.yaml
@@ -34,7 +34,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1b_red.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1b_red.yaml
@@ -39,7 +39,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1c_black.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1c_black.yaml
@@ -34,7 +34,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1c_red.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1c_red.yaml
@@ -39,7 +39,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1d_black.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1d_black.yaml
@@ -34,7 +34,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1d_red.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1d_red.yaml
@@ -39,7 +39,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1e_black.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1e_black.yaml
@@ -34,7 +34,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1e_red.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1e_red.yaml
@@ -39,7 +39,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1f_black.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1f_black.yaml
@@ -34,7 +34,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1f_red.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1f_red.yaml
@@ -39,7 +39,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1g_black.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1g_black.yaml
@@ -34,7 +34,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1g_red.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1g_red.yaml
@@ -39,7 +39,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1h_black.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1h_black.yaml
@@ -34,7 +34,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1h_red.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1h_red.yaml
@@ -39,7 +39,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1i_black.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1i_black.yaml
@@ -34,7 +34,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1i_red.yaml
+++ b/literature/mello_2018_bromide_18562/mello_2018_bromide_18562_f1i_red.yaml
@@ -39,7 +39,7 @@ source:
   citation key: mello_2018_bromide_18562
   url: https://doi.org/10.1021/acs.jpcc.8b05685
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1a_blue.yaml
+++ b/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1a_blue.yaml
@@ -41,7 +41,7 @@ source:
   techniques:
   - XAS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1a_green.yaml
+++ b/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1a_green.yaml
@@ -41,7 +41,7 @@ source:
   techniques:
   - XAS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1a_red.yaml
+++ b/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1a_red.yaml
@@ -41,7 +41,7 @@ source:
   techniques:
   - XAS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1b_blue.yaml
+++ b/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1b_blue.yaml
@@ -34,7 +34,7 @@ source:
   techniques:
   - XAS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1b_red.yaml
+++ b/literature/nakamura_2011_structure_165433/nakamura_2011_structure_165433_f1b_red.yaml
@@ -39,7 +39,7 @@ source:
   techniques:
   - XAS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/nakamura_2014_structural_22136/nakamura_2014_structural_22136_f1a_inset.yaml
+++ b/literature/nakamura_2014_structural_22136/nakamura_2014_structural_22136_f1a_inset.yaml
@@ -47,7 +47,7 @@ source:
   - time-resolved XRD 
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/ocko_1997_halide_55/ocko_1997_halide_55_f6a_solid.yaml
+++ b/literature/ocko_1997_halide_55/ocko_1997_halide_55_f6a_solid.yaml
@@ -32,7 +32,7 @@ source:
   techniques:
   - SXRD
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f1A_dotted.yaml
+++ b/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f1A_dotted.yaml
@@ -49,7 +49,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f1A_solid.yaml
+++ b/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f1A_solid.yaml
@@ -44,7 +44,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f1B_dotted.yaml
+++ b/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f1B_dotted.yaml
@@ -49,7 +49,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f1B_solid.yaml
+++ b/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f1B_solid.yaml
@@ -44,7 +44,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f3A_a.yaml
+++ b/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f3A_a.yaml
@@ -49,7 +49,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f3A_b.yaml
+++ b/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f3A_b.yaml
@@ -49,7 +49,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f3A_dashed.yaml
+++ b/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f3A_dashed.yaml
@@ -44,7 +44,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f8A_a.yaml
+++ b/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f8A_a.yaml
@@ -49,7 +49,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f8A_b.yaml
+++ b/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f8A_b.yaml
@@ -49,7 +49,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f8A_dashed.yaml
+++ b/literature/pajkossy_1996_impedance_209/pajkossy_1996_impedance_209_f8A_dashed.yaml
@@ -44,7 +44,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_2001_double_3063/pajkossy_2001_double_3063_f2_inset.yaml
+++ b/literature/pajkossy_2001_double_3063/pajkossy_2001_double_3063_f2_inset.yaml
@@ -41,7 +41,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_2001_double_3063/pajkossy_2001_double_3063_f5a_solid.yaml
+++ b/literature/pajkossy_2001_double_3063/pajkossy_2001_double_3063_f5a_solid.yaml
@@ -39,7 +39,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/pajkossy_2001_double_3063/pajkossy_2001_double_3063_f6a_solid.yaml
+++ b/literature/pajkossy_2001_double_3063/pajkossy_2001_double_3063_f6a_solid.yaml
@@ -39,7 +39,7 @@ source:
   techniques:
   - EIS
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/rehim_1998_electrochemical_1103/rehim_1998_electrochemical_1103_f1_solid.yaml
+++ b/literature/rehim_1998_electrochemical_1103/rehim_1998_electrochemical_1103_f1_solid.yaml
@@ -35,7 +35,7 @@ source:
   citation key: rehim_1998_electrochemical_1103
   url: https://doi.org/10.1007/PL00010123
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/sato_2006_effect_725/sato_2006_effect_725_p3_f4a_red.yaml
+++ b/literature/sato_2006_effect_725/sato_2006_effect_725_p3_f4a_red.yaml
@@ -51,7 +51,7 @@ system:
 source: 
   citation key: sato_2006_effect_725
   url: https://doi.org/10.1016/j.elecom.2006.03.001
-  version: 1
+  version: '1'
 curation:
   version: 1
   process:

--- a/literature/sato_2006_effect_725/sato_2006_effect_725_p3_f4b_red.yaml
+++ b/literature/sato_2006_effect_725/sato_2006_effect_725_p3_f4b_red.yaml
@@ -51,7 +51,7 @@ system:
 source: 
   citation key: sato_2006_effect_725
   url: https://doi.org/10.1016/j.elecom.2006.03.001
-  version: 1
+  version: '1'
 curation:
   version: 1
   process:

--- a/literature/sato_2006_effect_725/sato_2006_effect_725_p3_f4c_red.yaml
+++ b/literature/sato_2006_effect_725/sato_2006_effect_725_p3_f4c_red.yaml
@@ -51,7 +51,7 @@ system:
 source: 
   citation key: sato_2006_effect_725
   url: https://doi.org/10.1016/j.elecom.2006.03.001
-  version: 1
+  version: '1'
 curation:
   version: 1
   process:

--- a/literature/sato_2006_effect_725/sato_2006_effect_725_p3_f4d_red.yaml
+++ b/literature/sato_2006_effect_725/sato_2006_effect_725_p3_f4d_red.yaml
@@ -51,7 +51,7 @@ system:
 source: 
   citation key: sato_2006_effect_725
   url: https://doi.org/10.1016/j.elecom.2006.03.001
-  version: 1
+  version: '1'
 curation:
   version: 1
   process:

--- a/literature/schnaidt_2017_a_4141/schnaidt_2017_a_4141_f2_solid.yaml
+++ b/literature/schnaidt_2017_a_4141/schnaidt_2017_a_4141_f2_solid.yaml
@@ -66,7 +66,7 @@ source:
     - DEMS
     - ring disc
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/shi_1996_chloride_225/shi_1996_chloride_225_f1_dotted.yaml
+++ b/literature/shi_1996_chloride_225/shi_1996_chloride_225_f1_dotted.yaml
@@ -34,7 +34,7 @@ source:
   citation key: shi_1996_chloride_225
   url: https://doi.org/10.1016/0022-0728(92)80223-Q
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/shi_1996_chloride_225/shi_1996_chloride_225_f1_solid.yaml
+++ b/literature/shi_1996_chloride_225/shi_1996_chloride_225_f1_solid.yaml
@@ -39,7 +39,7 @@ source:
   citation key: shi_1996_chloride_225
   url: https://doi.org/10.1016/0022-0728(92)80223-Q
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/shi_1996_chloride_225/shi_1996_chloride_225_f1a_dashed.yaml
+++ b/literature/shi_1996_chloride_225/shi_1996_chloride_225_f1a_dashed.yaml
@@ -34,7 +34,7 @@ source:
   citation key: shi_1996_chloride_225
   url: https://doi.org/10.1016/0022-0728(92)80223-Q
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/shi_1996_chloride_225/shi_1996_chloride_225_f1a_solid.yaml
+++ b/literature/shi_1996_chloride_225/shi_1996_chloride_225_f1a_solid.yaml
@@ -39,7 +39,7 @@ source:
   citation key: shi_1996_chloride_225
   url: https://doi.org/10.1016/0022-0728(92)80223-Q
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/wandlowski_1996_structural_10277/wandlowski_1996_structural_10277_f1a_dashed.yaml
+++ b/literature/wandlowski_1996_structural_10277/wandlowski_1996_structural_10277_f1a_dashed.yaml
@@ -34,7 +34,7 @@ source:
   techniques:
   - SXRD
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/wandlowski_1996_structural_10277/wandlowski_1996_structural_10277_f1a_solid.yaml
+++ b/literature/wandlowski_1996_structural_10277/wandlowski_1996_structural_10277_f1a_solid.yaml
@@ -34,7 +34,7 @@ source:
   techniques:
   - SXRD
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/wang_1996_ordered_6672/wang_1996_ordered_6672_f1_solid.yaml
+++ b/literature/wang_1996_ordered_6672/wang_1996_ordered_6672_f1_solid.yaml
@@ -32,7 +32,7 @@ source:
   techniques:
   - SXRD
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/wang_1996_ordered_6672/wang_1996_ordered_6672_f2a_solid.yaml
+++ b/literature/wang_1996_ordered_6672/wang_1996_ordered_6672_f2a_solid.yaml
@@ -32,7 +32,7 @@ source:
   techniques:
   - SXRD
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/wang_1996_ordered_6672/wang_1996_ordered_6672_f2b_solid.yaml
+++ b/literature/wang_1996_ordered_6672/wang_1996_ordered_6672_f2b_solid.yaml
@@ -32,7 +32,7 @@ source:
   techniques:
   - SXRD
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/wang_1997_lateral_1/wang_1997_lateral_1_f1a_solid.yaml
+++ b/literature/wang_1997_lateral_1/wang_1997_lateral_1_f1a_solid.yaml
@@ -36,7 +36,7 @@ source:
   techniques:
   - SXRD
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/zei_1991_the_295/zei_1991_the_295_f3a_solid.yaml
+++ b/literature/zei_1991_the_295/zei_1991_the_295_f3a_solid.yaml
@@ -37,7 +37,7 @@ source:
   - RHEED 
   - AES
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:

--- a/literature/zei_1991_the_295/zei_1991_the_295_f3b_solid.yaml
+++ b/literature/zei_1991_the_295/zei_1991_the_295_f3b_solid.yaml
@@ -42,7 +42,7 @@ source:
   - RHEED 
   - AES
   version: 1
-version: 1
+version: '1'
 curation:
   version: 1
   process:


### PR DESCRIPTION
Top-level version number in a frictionless datapackage must be a string.