### PR TITLE
Update dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - astropy
   - black
-  #- echemdb>=0.4.0,<0.5.0
+  - echemdb>=0.6.0,<0.7.0
   - isort
   - make
   # In early 2022 we had trouble with some recent versions of mkdocs. To work around this issue, we pin mkdocs versions exactly. This pin can likely be relaxed again.
@@ -39,4 +39,3 @@ dependencies:
     - pymdown-extensions>=9.2,<10
     - python-frontmatter
     - tabulate
-    - git+https://github.com/echemdb/echemdb.git@refs/pull/54/head

--- a/environment.yml
+++ b/environment.yml
@@ -10,8 +10,8 @@ dependencies:
   - make
   # In early 2022 we had trouble with some recent versions of mkdocs. To work around this issue, we pin mkdocs versions exactly. This pin can likely be relaxed again.
   - mkdocs=1.3.0
-  - myst-nb>=0.13.0,<0.14.0
-  - myst-parser>=0.15,<0.17
+  - myst-nb>=0.17.0,<0.18.0
+  - myst-parser>=0.18.0,<0.19.0
   - pip
   - pylatexenc>=2.10,<3
   - pylint


### PR DESCRIPTION
Updates the echemdb dependency, which also requires changes to the myst dependencies due to conflicts with the latest version of frictionless.