### PR TITLE
Update to unitpackage and adapt documentation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - astropy
   - black
-  #- echemdb>=0.4.0,<0.5.0
+  - unitpackage>=0.7.0,<0.8.0
   - isort
   - make
   # In early 2022 we had trouble with some recent versions of mkdocs. To work around this issue, we pin mkdocs versions exactly. This pin can likely be relaxed again.
@@ -39,4 +39,3 @@ dependencies:
     - pymdown-extensions>=9.2,<10
     - python-frontmatter
     - tabulate
-    - git+https://github.com/echemdb/echemdb.git@refs/pull/54/head

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - astropy
   - black
-  - unitpackage>=0.7.0,<0.8.0
+  - echemdb>=0.6.0,<0.7.0
   - isort
   - make
   # In early 2022 we had trouble with some recent versions of mkdocs. To work around this issue, we pin mkdocs versions exactly. This pin can likely be relaxed again.

--- a/pages/NAVIGATION.md
+++ b/pages/NAVIGATION.md
@@ -3,5 +3,5 @@
     * [Aqueous](cv/aqueous.md)
         * [COOR](cv/aqueous/COOR.md)
     * [Ionic Liquid](cv/ionic_liquid.md)
-* [API](https://echemdb.github.io/echemdb/)
+* [API](https://echemdb.github.io/unitpackage/)
 * [About](about.md)

--- a/pages/about.md
+++ b/pages/about.md
@@ -1,25 +1,30 @@
 # About the project
 
-echemdb aims at standardizing experimental and theoretical data on electrochemical systems
+The echemDB projects aim at standardizing experimental and theoretical 3D or time series data
 according to the [FAIR principles](https://www.go-fair.org/fair-principles/).
 Ultimately, this approach allows for a seamless comparison of published data
 with laboratory-derived data and theoretical models.
 
-The key issues for compliance with the FAIR principles for electrochemical data
+The tools are developed focusing on electrochemical data.
+The key issues for compliance with the FAIR principles for these data
 are (i) metadata standards and (ii) accessibility to published data
-which are often not machine-readable.
+which are often not machine-readable. More specifically, research data often stored as CSV
+usually do not contain information on the units of the axis/columns or contain metadata annotating
+and describing the data.
 
-To solve these issues, in a first step the authors of echemdb limit themselves to a popular research
+To solve these issues, in a first step the authors of echemDB limit themselves to a popular research
 field of electrochemistry. In recent decades, the study
 of the electrochemical properties of well-defined single crystal electrodes by
 cyclic voltammetry has played a crucial role in the fundamental understanding of more
 complex three dimensional systems found in more applied research areas or even in application.
+These materials are very well defined and the measurement principle is also well established
+within the community.
 
 ## Standardization
 
-To standardize electrochemical data the authors of echemdb adopt
-the [data package](https://specs.frictionlessdata.io/data-package/#introduction)
-structure developed by [frictionless](https://frictionlessdata.io/).
+To standardize CVS data the authors of echemDB adopt
+the [frictionless datapackage](https://specs.frictionlessdata.io/data-package/#introduction)
+structure.
 According to frictionless a data package consists of:
 
 > * Metadata that describes the structure and contents of the package
@@ -27,7 +32,13 @@ According to frictionless a data package consists of:
 >
 > The Data Package metadata is stored in a “descriptor”.
 
-The metadata describe for example the [electrochemical system](https://github.com/echemdb/metadata-schema/blob/main/examples/objects/system.yaml),
+The frictionless resource descriptors are enhanced by
+
+The echemDB authors augmented the frictionless schema, by adding
+
+* units, allowing for simple unit transformations or data manipulation.
+* metadata describing a resource within the package.
+The metadata describes for example the [electrochemical system](https://github.com/echemdb/metadata-schema/blob/main/examples/objects/system.yaml),
 which contains detailed information about the electrodes
 or the components of the electrolyte. The metadata also contains information
 on the curation process, i.e., who was the experimentalist,
@@ -35,49 +46,49 @@ a URL to an entry in an electronic laboratory notebook (ELN), or details on the 
 The [JSON metadata schema](https://github.com/echemdb/metadata-schema) is developed
 as a separate project.
 
-The frictionless resource descriptors are enhanced by units,
-allowing for simple unit transformations or data manipulation.
-
-By following this approach, a set of data packages forms a database.
-The entries of such a database are displayed in different forms on this
+By following this approach, a set of datapackages forms a collection.
+The entries of such a collection are displayed in different forms on this
 website based on the available descriptors.
-A [Python API](https://echemdb.github.io/echemdb/) provides direct access
-to the entries of such a database, enabling more specific filtering,
+A [Python API](https://echemdb.github.io/unitpackage/) provides direct access
+to the entries of such a collection, enabling more specific filtering,
 and enabling seamless integration into existing workflows.
 
 ## Reusability
 
-In order to improve the reusability of published data, the authors of echemdb created
+In order to improve the reusability of published data, the authors of echemDB created
 [svgdigitizer](https://echemdb.github.io/svgdigitizer/), a tool allowing for
 digitizing any kind of published 2D plots from carefully prepared SVG files.
-An [electrochemistry module](https://echemdb.github.io/svgdigitizer/workflow.html)
-offers convenience functionality, e.g., to reconstruct a time
-axis based on the scan rate, extract axis units, or reference potentials.
-By providing a set of metadata, the digitized data can directly be stored as an echemdb data package.
+This approach has some superior functionalities compared to other tools, for example,
+allowing to extract units from the axis labels or reconstructing a time axis based on a given scan rate.
+Modules for specific types of plots, auch as the [electrochemistry module](https://echemdb.github.io/svgdigitizer/workflow.html)
+offers convenience functionality, and allow extracting additional properties such as the reference potential of a potential axis.
+By providing a set of metadata, the digitized data can directly be stored as a [unitpackage](https://echemdb.github.io/unitpackage/).
 
 ## Contribute
 
 Contributions are always welcome and do not necessarily require programming skills.
-Please leave us a message if you are interested in contributing to the echemdb.
+Please [leave us a message](https://github.com/orgs/echemdb/discussions)
+if you are interested in contributing to the echemDB.
 
 You could get started by [digitizing some published data](https://echemdb.github.io/svgdigitizer/workflow.html)
-in your area of research or by extending any of the pages of the [echemdb website](https://echemdb.github.io/website/).
+in your area of research or by extending any of the pages of the [echemDB website](https://echemdb.github.io/website/).
 If your interest is outside of cyclic voltammograms or electrochemistry,
 we would also be thrilled to hear about your ideas to extend these projects to other areas.
 
 ## What's next
 
 The collection of metadata for a single measurement in the laboratory is often a tedious task.
-We are currently developing a tool that stores a predefined set of metadata along with the measurement data.
+We are currently [developing a tool](https://github.com/echemdb/autotag-metadata)
+that stores a predefined set of metadata along with the measurement data.
 Furthermore we develop file converters for electrochemical data,
-which in combination with the metadata files produce an echemdb data package.
+which in combination with the metadata files produce a [unitpackage](https://echemdb.github.io/unitpackage/).
 
 ## Contact
 
-The authors of echemdb are from the fields of experimental and theoretical physical chemistry,
+The authors of echemDB are from the fields of experimental and theoretical physical chemistry,
 as well as from computer science and mathematics.
 
-E-mail: contact@echemdb.org
+Ideas and suggestions, tell us more on our [discussion board](https://github.com/orgs/echemdb/discussions).
 
 Reach individual contributors on the [GitHub organization](https://github.com/echemdb).
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -11,7 +11,7 @@ hide:
 <figcaption markdown>
 ## Philosophy
 
-echemdb aims at standardizing electrochemical data according to the
+echemdb aims at standardizing (electrochemical) data according to the
 [FAIR principles](https://www.go-fair.org/fair-principles/), allowing
 comparison of published data with data acquired
 in the laboratory, and theoretical models.
@@ -40,8 +40,7 @@ which were standardized and validated from published works by the community.
 The echemdb Python module provides an interactive way to visualize, filter,
 or evaluate the entries in the database.
 
-[→ Explore](https://mybinder.org/v2/gh/echemdb/echemdb/0.3.0?urlpath=tree%2Fdoc%2Fusage%2Fentry_interactions.md)  
-[→ Documentation](https://echemdb.github.io/echemdb/)
+[→ Documentation](https://echemdb.github.io/unitpackage/)
 
 </figcaption>
 </figure>
@@ -67,7 +66,7 @@ The svgdigitizer recovers data
 from published figures,
 where machine-readable data is not available.
 
-[→ Learn more](https://echemdb.github.io/svgdigitizer/)  
+[→ Learn more](https://echemdb.github.io/svgdigitizer/)
 [→ Digitize a plot for echemdb](https://echemdb.github.io/svgdigitizer/workflow.html)
 
 </figcaption>


### PR DESCRIPTION
Changed from `echemdb` to `unitpackage`.
* Currently only for the text on the website. The page is still build with echemdb, as long as unitpackage is not part of conda-forge

Also improved the description of our ongoing projects.

